### PR TITLE
Admin DB Cleanup for TmWorkspaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'org.janelia.jacs-model'
-    version = '3.3.0'
+    version = '3.3.4'
 }
 
 subprojects {

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
@@ -18,4 +18,5 @@ public interface TmWorkspaceDao extends DomainObjectDao<TmWorkspace> {
     void saveWorkspaceBoundingBoxes(TmWorkspace workspace, List<BoundingBox3d> boundingBoxes);
     List<BoundingBox3d> getWorkspaceBoundingBoxes(Long workspaceId);
     List<TmWorkspaceInfo> getLargestWorkspaces(String subjectKey, Long limit);
+    long deleteByIdAndSubjectKey(Long id, String subjectKey);
 }

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
@@ -2,9 +2,9 @@ package org.janelia.model.access.domain.dao;
 
 import org.janelia.model.domain.tiledMicroscope.BoundingBox3d;
 import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
+import org.janelia.model.domain.tiledMicroscope.TmWorkspaceInfo;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * TmWorkspace data access object
@@ -17,5 +17,5 @@ public interface TmWorkspaceDao extends DomainObjectDao<TmWorkspace> {
     TmWorkspace updateTmWorkspace(String subjectKey, TmWorkspace tmWorkspace);
     void saveWorkspaceBoundingBoxes(TmWorkspace workspace, List<BoundingBox3d> boundingBoxes);
     List<BoundingBox3d> getWorkspaceBoundingBoxes(Long workspaceId);
-    Map<TmWorkspace, Long> getLargestWorkspaces(String subjectKey, Long limit);
+    List<TmWorkspaceInfo> getLargestWorkspaces(String subjectKey, Long limit);
 }

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/TmWorkspaceDao.java
@@ -4,6 +4,7 @@ import org.janelia.model.domain.tiledMicroscope.BoundingBox3d;
 import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * TmWorkspace data access object
@@ -16,5 +17,5 @@ public interface TmWorkspaceDao extends DomainObjectDao<TmWorkspace> {
     TmWorkspace updateTmWorkspace(String subjectKey, TmWorkspace tmWorkspace);
     void saveWorkspaceBoundingBoxes(TmWorkspace workspace, List<BoundingBox3d> boundingBoxes);
     List<BoundingBox3d> getWorkspaceBoundingBoxes(Long workspaceId);
-
+    Map<TmWorkspace, Long> getLargestWorkspaces(String subjectKey, Long limit);
 }

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/MongoDaoHelper.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/MongoDaoHelper.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
+import com.mongodb.WriteConcern;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/MongoDaoHelper.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/MongoDaoHelper.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
-import com.mongodb.WriteConcern;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmMappedNeuronMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmMappedNeuronMongoDao.java
@@ -42,7 +42,7 @@ public class TmMappedNeuronMongoDao extends AbstractDomainObjectMongoDao<TmMappe
     public long deleteNeuronsForWorkspace(TmWorkspace workspace, String subjectKey) {
 
         LOG.info("Deleting neurons from workspace {} in mongo collection {}",
-                workspace.getName(), mongoCollection.getNamespace().getCollectionName());
+                workspace.getName(), workspace.getNeuronCollection());
         return MongoDaoHelper.deleteMatchingRecords(mongoCollection,
                 Filters.and(MongoDaoHelper.createFilterCriteria(
                         Filters.eq("workspaceRef", Reference.createFor(workspace))

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmMappedNeuronMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmMappedNeuronMongoDao.java
@@ -7,11 +7,15 @@ import org.janelia.model.access.domain.dao.TmMappedNeuronDao;
 import org.janelia.model.domain.Reference;
 import org.janelia.model.domain.tiledMicroscope.TmMappedNeuron;
 import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.List;
 
 public class TmMappedNeuronMongoDao extends AbstractDomainObjectMongoDao<TmMappedNeuron> implements TmMappedNeuronDao {
+    private static final Logger LOG = LoggerFactory.getLogger(TmMappedNeuronMongoDao.class);
+
 
     @Inject
     TmMappedNeuronMongoDao(MongoDatabase mongoDatabase,
@@ -36,7 +40,9 @@ public class TmMappedNeuronMongoDao extends AbstractDomainObjectMongoDao<TmMappe
 
     @Override
     public long deleteNeuronsForWorkspace(TmWorkspace workspace, String subjectKey) {
-        // TODO: this should remove the deleted documents from the search index
+
+        LOG.info("Deleting neurons from workspace {} in mongo collection {}",
+                workspace.getName(), mongoCollection.getNamespace().getCollectionName());
         return MongoDaoHelper.deleteMatchingRecords(mongoCollection,
                 Filters.and(MongoDaoHelper.createFilterCriteria(
                         Filters.eq("workspaceRef", Reference.createFor(workspace))

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
@@ -447,10 +447,10 @@ public class TmNeuronMetadataMongoDao extends AbstractDomainObjectMongoDao<TmNeu
     public long deleteNeuronsForWorkspace(TmWorkspace workspace, String subjectKey) {
         LOG.info("Deleting neurons from workspace {} in mongo collection {}",
                 workspace.getName(), workspace.getNeuronCollection());
-        return MongoDaoHelper.deleteMatchingRecords(getNeuronCollection(workspace.getNeuronCollection()),
-                Filters.and(MongoDaoHelper.createFilterCriteria(
-                        Filters.eq("workspaceRef", Reference.createFor(workspace))
-                ), permissionsHelper.createWritePermissionFilterForSubjectKey(subjectKey)));
+        return MongoDaoHelper.deleteMatchingRecords(
+                getNeuronCollection(workspace.getNeuronCollection()),
+                Filters.eq("workspaceRef", Reference.createFor(workspace))  // Simplified filter
+        );
     }
 
     private MongoCollection<TmNeuronMetadata> getNeuronCollection(String collectionName) {

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
@@ -310,15 +310,12 @@ public class TmNeuronMetadataMongoDao extends AbstractDomainObjectMongoDao<TmNeu
 
     private TmNeuronMetadata createNeuronWithExistingId(TmNeuronMetadata entity,
                                                         String collectionName, String subjectKey) {
-        LOG.info("TRACE1");
         MongoCollection<TmNeuronMetadata> mongoCollection =  getNeuronCollection(collectionName);
 
         Date now = new Date();
-        LOG.info("TRACE2");
         for (TmGeoAnnotation anno : entity.getRootAnnotations()) {
             anno.setParentId(entity.getId());
         }
-        LOG.info("TRACE3");
         entity.setOwnerKey(subjectKey);
         entity.getReaders().add(subjectKey);
         entity.getWriters().add(subjectKey);
@@ -448,6 +445,8 @@ public class TmNeuronMetadataMongoDao extends AbstractDomainObjectMongoDao<TmNeu
 
     @Override
     public long deleteNeuronsForWorkspace(TmWorkspace workspace, String subjectKey) {
+        LOG.info("Deleting neurons from workspace {} in mongo collection {}",
+                workspace.getName(), mongoCollection.getNamespace().getCollectionName());
         return MongoDaoHelper.deleteMatchingRecords(mongoCollection,
                 Filters.and(MongoDaoHelper.createFilterCriteria(
                         Filters.eq("workspaceRef", Reference.createFor(workspace))

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
@@ -446,8 +446,8 @@ public class TmNeuronMetadataMongoDao extends AbstractDomainObjectMongoDao<TmNeu
     @Override
     public long deleteNeuronsForWorkspace(TmWorkspace workspace, String subjectKey) {
         LOG.info("Deleting neurons from workspace {} in mongo collection {}",
-                workspace.getName(), mongoCollection.getNamespace().getCollectionName());
-        return MongoDaoHelper.deleteMatchingRecords(mongoCollection,
+                workspace.getName(), workspace.getNeuronCollection());
+        return MongoDaoHelper.deleteMatchingRecords(getNeuronCollection(workspace.getNeuronCollection()),
                 Filters.and(MongoDaoHelper.createFilterCriteria(
                         Filters.eq("workspaceRef", Reference.createFor(workspace))
                 ), permissionsHelper.createWritePermissionFilterForSubjectKey(subjectKey)));

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
@@ -117,7 +117,7 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
 
             // Aggregate to calculate the total size of neuron documents without fetching them
             AggregateIterable<Document> aggregation = neuronCollection.aggregate(Arrays.asList(
-                    Aggregates.match(new Document("workspaceRef", workspace.getId().toString())), // Add this line
+                    Aggregates.match(new Document("workspaceRef", "TmWorkspace#"+workspace.getId().toString())), // Add this line
                     Aggregates.project(Projections.fields(
                             Projections.computed("size", new Document("$bsonSize", "$$ROOT"))
                     )),

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
@@ -313,6 +313,7 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
         catch (Exception e) {
             throw new IllegalStateException("Error deleting neuron metadata for workspace "+workspace, e);
         }
+        gridFSMongoDao.deleteDataBlock(workspace.getId().toString());
         n += super.deleteByIdAndSubjectKey(workspace.getId(), subjectKey);
         return n;
     }

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
@@ -27,6 +27,7 @@ import org.janelia.model.access.domain.DomainDAO;
 import org.janelia.model.access.domain.dao.TmMappedNeuronDao;
 import org.janelia.model.access.domain.dao.TmNeuronMetadataDao;
 import org.janelia.model.access.domain.dao.TmWorkspaceDao;
+import org.janelia.model.domain.tiledMicroscope.TmWorkspaceInfo;
 import org.janelia.model.domain.DomainConstants;
 import org.janelia.model.domain.Reference;
 import org.janelia.model.domain.tiledMicroscope.*;
@@ -97,68 +98,62 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
     }
 
     @Override
-    public Map<TmWorkspace, Long> getLargestWorkspaces(String subjectKey, Long limit) {
+    public List<TmWorkspaceInfo> getLargestWorkspaces(String subjectKey, Long limit) {
         // Step 1: Get all accessible workspaces using existing method
         List<TmWorkspace> workspaces = getAllTmWorkspaces(subjectKey);
 
-        Map<TmWorkspace, Long> workspaceSizeMap = new HashMap<>();
+        List<TmWorkspaceInfo> workspaceInfoList = new ArrayList<>();
 
         // Step 2: Use parallel processing for faster aggregation
         ForkJoinPool customThreadPool = new ForkJoinPool(8); // Limit to 8 threads
-        workspaceSizeMap = customThreadPool.submit(() ->
+        workspaceInfoList = customThreadPool.submit(() ->
                 workspaces.parallelStream()
-                        .collect(Collectors.toMap(
-                                workspace -> workspace,
-                                workspace -> {
-                                    String neuronCollectionName = workspace.getNeuronCollection();
-                                    if (neuronCollectionName == null || neuronCollectionName.isEmpty()) {
-                                        return 0L;
-                                    }
+                        .map(workspace -> {
+                            String neuronCollectionName = workspace.getNeuronCollection();
+                            if (neuronCollectionName == null || neuronCollectionName.isEmpty()) {
+                                return new TmWorkspaceInfo(workspace.getId(), workspace.getName(),
+                                        0L, workspace.getOwnerKey(), workspace.getCreationDate());
+                            }
 
-                                    MongoCollection<Document> neuronCollection = mongoDatabase.getCollection(neuronCollectionName);
+                            MongoCollection<Document> neuronCollection = mongoDatabase.getCollection(neuronCollectionName);
 
-                                    LOG.info("Analyzing {} workspace storing neurons in {}",
-                                            workspace.getName(), neuronCollectionName);
+                            LOG.info("Analyzing {} workspace storing neurons in {}",
+                                    workspace.getName(), neuronCollectionName);
 
-                                    Long totalSize = 0L;
-                                    try {
-                                        String workspaceRef = "TmWorkspace#" + workspace.getId();
-                                        AggregateIterable<Document> aggregation = neuronCollection.aggregate(Arrays.asList(
-                                                Aggregates.match(Filters.eq("workspaceRef", workspaceRef)),
-                                                Aggregates.project(Projections.fields(
-                                                        Projections.computed("size", new Document("$bsonSize", "$$ROOT"))
-                                                )),
-                                                Aggregates.group(null, Accumulators.sum("totalSize", "$size"))
-                                        ));
+                            Long totalSize = 0L;
+                            try {
+                                String workspaceRef = "TmWorkspace#" + workspace.getId();
+                                AggregateIterable<Document> aggregation = neuronCollection.aggregate(Arrays.asList(
+                                        Aggregates.match(Filters.eq("workspaceRef", workspaceRef)),
+                                        Aggregates.project(Projections.fields(
+                                                Projections.computed("size", new Document("$bsonSize", "$$ROOT"))
+                                        )),
+                                        Aggregates.group(null, Accumulators.sum("totalSize", "$size"))
+                                ));
 
-                                        for (Document result : aggregation) {
-                                            Number size = result.get("totalSize", Number.class);
-                                            totalSize = size != null ? size.longValue() : 0L;
-                                        }
-                                    } catch (Exception e) {
-                                        LOG.error("Error processing workspace: {}", workspace.getName(), e);
-                                    }
-
-                                    LOG.info("Finished aggregation analysis for {}", workspace.getName());
-                                    return totalSize;
+                                for (Document result : aggregation) {
+                                    Number size = result.get("totalSize", Number.class);
+                                    totalSize = size != null ? size.longValue() : 0L;
                                 }
-                        ))
+                            } catch (Exception e) {
+                                LOG.error("Error processing workspace: {}", workspace.getName(), e);
+                            }
+
+                            LOG.info("Finished aggregation analysis for {}", workspace.getName());
+                            return new TmWorkspaceInfo(workspace.getId(), workspace.getName(),
+                                    totalSize, workspace.getOwnerKey(), workspace.getCreationDate());
+                        })
+                        .sorted((w1, w2) -> Long.compare(w2.getTotalSize(), w1.getTotalSize())) // Sort by total size in descending order
+                        .limit(limit) // Limit the results
+                        .collect(Collectors.toList())
         ).join();
 
         customThreadPool.shutdown();
-        LOG.info("Workspace analysis complete. Results: {}", workspaceSizeMap);
+        LOG.info("Workspace analysis complete. Results: {}", workspaceInfoList);
 
-        // Sort by total size in descending order and limit results
-        return workspaceSizeMap.entrySet().stream()
-                .sorted(Map.Entry.<TmWorkspace, Long>comparingByValue().reversed())
-                .limit(limit)
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (e1, e2) -> e1,
-                        LinkedHashMap::new
-                ));
+        return workspaceInfoList;
     }
+
 
     @Override
     public TmWorkspace createTmWorkspace(String subjectKey, TmWorkspace tmWorkspace) {

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
@@ -106,9 +106,6 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
         // Step 2: Iterate through workspaces and aggregate neuron document sizes
         for (TmWorkspace workspace : workspaces) {
             String neuronCollectionName = workspace.getNeuronCollection();
-
-            LOG.info("Analyzing {} workspace storing neurons in {}",
-                    workspace.getName(),neuronCollectionName);
             if (neuronCollectionName == null || neuronCollectionName.isEmpty()) {
                 continue; // Skip workspaces without a valid neuron collection
             }
@@ -124,11 +121,13 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
                     Aggregates.group(null, Accumulators.sum("totalSize", "$size"))
             ));
 
-            LOG.info("Finished aggregation analysis");
             // Extract the total size from the aggregation result
             Long totalSize = 0L;
             for (Document result : aggregation) {
-                totalSize = result.getLong("totalSize");
+                Number size = result.get("totalSize", Number.class);
+                if (size != null) {
+                    totalSize = size.longValue();
+                }
             }
 
             workspaceSizeMap.put(workspace, totalSize);

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmWorkspaceMongoDao.java
@@ -117,6 +117,7 @@ public class TmWorkspaceMongoDao extends AbstractDomainObjectMongoDao<TmWorkspac
 
             // Aggregate to calculate the total size of neuron documents without fetching them
             AggregateIterable<Document> aggregation = neuronCollection.aggregate(Arrays.asList(
+                    Aggregates.match(new Document("workspaceRef", workspace.getId().toString())), // Add this line
                     Aggregates.project(Projections.fields(
                             Projections.computed("size", new Document("$bsonSize", "$$ROOT"))
                     )),

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
@@ -37,6 +37,11 @@ public class TmWorkspaceSearchableDao extends AbstractDomainSearchableDao<TmWork
     }
 
     @Override
+    public long deleteByIdAndSubjectKey(Long id, String subjectKey) {
+        return tmWorkspaceDao.deleteByIdAndSubjectKey(id, subjectKey);
+    }
+
+    @Override
     public TmWorkspace createTmWorkspace(String subjectKey, TmWorkspace tmWorkspace) {
         TmWorkspace persistedTmWorkspace = tmWorkspaceDao.createTmWorkspace(subjectKey, tmWorkspace);
         domainObjectIndexer.indexDocument(persistedTmWorkspace);

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
@@ -1,8 +1,6 @@
 package org.janelia.model.access.domain.dao.searchables;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -11,6 +9,7 @@ import org.janelia.model.access.domain.dao.TmWorkspaceDao;
 import org.janelia.model.access.domain.search.DomainObjectIndexer;
 import org.janelia.model.domain.tiledMicroscope.BoundingBox3d;
 import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
+import org.janelia.model.domain.tiledMicroscope.TmWorkspaceInfo;
 
 /**
  * {@link TmWorkspace} DAO.
@@ -69,7 +68,7 @@ public class TmWorkspaceSearchableDao extends AbstractDomainSearchableDao<TmWork
     }
 
     @Override
-    public Map<TmWorkspace, Long> getLargestWorkspaces(String subjectKey, Long limit) {
+    public List<TmWorkspaceInfo> getLargestWorkspaces(String subjectKey, Long limit) {
         return tmWorkspaceDao.getLargestWorkspaces(subjectKey, limit);
     }
 }

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/searchables/TmWorkspaceSearchableDao.java
@@ -1,6 +1,8 @@
 package org.janelia.model.access.domain.dao.searchables;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -64,5 +66,10 @@ public class TmWorkspaceSearchableDao extends AbstractDomainSearchableDao<TmWork
     @Override
     public List<BoundingBox3d> getWorkspaceBoundingBoxes(Long workspaceId) {
         return tmWorkspaceDao.getWorkspaceBoundingBoxes(workspaceId);
+    }
+
+    @Override
+    public Map<TmWorkspace, Long> getLargestWorkspaces(String subjectKey, Long limit) {
+        return tmWorkspaceDao.getLargestWorkspaces(subjectKey, limit);
     }
 }

--- a/jacs-model-core/src/main/java/org/janelia/model/domain/tiledMicroscope/TmWorkspaceInfo.java
+++ b/jacs-model-core/src/main/java/org/janelia/model/domain/tiledMicroscope/TmWorkspaceInfo.java
@@ -9,6 +9,9 @@ public class TmWorkspaceInfo {
     private String ownerKey;
     private Date dateCreated;
 
+    public TmWorkspaceInfo() {
+    }
+
     public TmWorkspaceInfo(Long workspaceId, String workspaceName, Long totalSize, String ownerKey, Date dateCreated) {
         this.workspaceId = workspaceId;
         this.workspaceName = workspaceName;

--- a/jacs-model-core/src/main/java/org/janelia/model/domain/tiledMicroscope/TmWorkspaceInfo.java
+++ b/jacs-model-core/src/main/java/org/janelia/model/domain/tiledMicroscope/TmWorkspaceInfo.java
@@ -1,0 +1,61 @@
+package org.janelia.model.domain.tiledMicroscope;
+
+import java.util.Date;
+
+public class TmWorkspaceInfo {
+    private Long workspaceId;
+    private String workspaceName;
+    private Long totalSize;
+    private String ownerKey;
+    private Date dateCreated;
+
+    public TmWorkspaceInfo(Long workspaceId, String workspaceName, Long totalSize, String ownerKey, Date dateCreated) {
+        this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
+        this.totalSize = totalSize;
+        this.ownerKey = ownerKey;
+        this.dateCreated = dateCreated;
+    }
+
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    public Date getDateCreated() {
+        return dateCreated;
+    }
+
+    public void setDateCreated(Date dateCreated) {
+        this.dateCreated = dateCreated;
+    }
+
+    public Long getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(Long workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public Long getTotalSize() {
+        return totalSize;
+    }
+
+    public void setTotalSize(Long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    public String getOwnerKey() {
+        return ownerKey;
+    }
+
+    public void setOwnerKey(String ownerKey) {
+        this.ownerKey = ownerKey;
+    }
+}
+
+


### PR DESCRIPTION
This are model changes for a new admin functionin the GUI for cleaning up large TmWorkspaces.  It first searches through the database to return the largest workspaces, then allows the user to select the workspaces for removal.  It also fixes an issue with workspace deletion to target the actual neuron collection where the workspace's neurons were stored.  

This is intended for admins of HortaCloud to clean up their Mongo database by removing large fragment workspaces that might be taking a lot of memory on disk.