### PR TITLE
One more fix for closing opened streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'org.janelia.jacs-model'
-    version = '3.3.4'
+    version = '3.3.5'
 }
 
 subprojects {

--- a/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
+++ b/jacs-model-access/src/main/java/org/janelia/model/access/domain/dao/mongo/TmNeuronMetadataMongoDao.java
@@ -1,5 +1,15 @@
 package org.janelia.model.access.domain.dao.mongo;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -17,17 +27,22 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.bson.conversions.Bson;
 import org.janelia.model.access.domain.TimebasedIdentifierGenerator;
-import org.janelia.model.access.domain.dao.*;
+import org.janelia.model.access.domain.dao.AppendFieldValueHandler;
+import org.janelia.model.access.domain.dao.DaoUpdateResult;
+import org.janelia.model.access.domain.dao.EntityFieldValueHandler;
+import org.janelia.model.access.domain.dao.RemoveItemsFieldValueHandler;
+import org.janelia.model.access.domain.dao.SetFieldValueHandler;
+import org.janelia.model.access.domain.dao.TmNeuronMetadataDao;
 import org.janelia.model.domain.Reference;
-import org.janelia.model.domain.tiledMicroscope.*;
+import org.janelia.model.domain.tiledMicroscope.BulkNeuronStyleUpdate;
+import org.janelia.model.domain.tiledMicroscope.TmGeoAnnotation;
+import org.janelia.model.domain.tiledMicroscope.TmNeuronData;
+import org.janelia.model.domain.tiledMicroscope.TmNeuronMetadata;
+import org.janelia.model.domain.tiledMicroscope.TmOperation;
+import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
 import org.janelia.model.security.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.util.*;
 
 /**
  * {@link TmNeuronMetadata} Mongo DAO.

--- a/jacs-model-rendering/src/main/java/org/janelia/rendering/FileBasedRenderedVolumeLocation.java
+++ b/jacs-model-rendering/src/main/java/org/janelia/rendering/FileBasedRenderedVolumeLocation.java
@@ -109,7 +109,7 @@ public class FileBasedRenderedVolumeLocation extends FileBasedDataLocation imple
         byte[] imageTextureBytes = ImageUtils.bandMergedTextureBytesFromImageStreams(
                 channelImageNames.stream()
                         .map(channelImageName -> Paths.get(getBaseDataStoragePath(), imageRelativePath, channelImageName))
-                        .filter(channelImagePath -> Files.exists(channelImagePath))
+                        .filter(Files::exists)
                         .map(channelImagePath -> NamedSupplier.namedSupplier(
                                 channelImagePath.toString(),
                                 () -> {

--- a/jacs-model-rendering/src/main/java/org/janelia/rendering/RenderedImagesWithStreams.java
+++ b/jacs-model-rendering/src/main/java/org/janelia/rendering/RenderedImagesWithStreams.java
@@ -12,7 +12,6 @@ import javax.media.jai.JAI;
 import javax.media.jai.ParameterBlockJAI;
 
 import com.google.common.base.Stopwatch;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,24 +56,24 @@ public class RenderedImagesWithStreams {
     public RenderedImageWithStream combine(String operation) {
         Stopwatch stopwatch = Stopwatch.createStarted();
         try {
-            if (renderedImages.size() == 0) {
+            if (renderedImages.isEmpty()) {
                 return null;
             } else if (renderedImages.size() == 1) {
                 return new RenderedImageWithStream(renderedImages.get(0), renderedImageStreams.get(0));
             } else {
                 ParameterBlock combinedImages = new ParameterBlockJAI(operation);
-                renderedImages.forEach(rim -> combinedImages.addSource(rim));
+                renderedImages.forEach(combinedImages::addSource);
                 LOG.debug("Adding all sources {} for {} took {} ms", renderedImageNames, operation, stopwatch.elapsed(TimeUnit.MILLISECONDS));
                 return new RenderedImageWithStream(
                         JAI.create(operation, combinedImages, null),
                         new InputStream() {
                             @Override
-                            public int read() throws IOException {
+                            public int read() {
                                 throw new UnsupportedOperationException("Read is not supported from a final combined stream which is created only for being able to close all underlying streams");
                             }
 
                             @Override
-                            public void close() throws IOException {
+                            public void close() {
                                 RenderedImagesWithStreams.this.close();
                             }
                         }

--- a/jacs-model-rendering/src/main/java/org/janelia/rendering/utils/ImageUtils.java
+++ b/jacs-model-rendering/src/main/java/org/janelia/rendering/utils/ImageUtils.java
@@ -307,16 +307,13 @@ public class ImageUtils {
     }
 
     @Nullable
-    public static byte[] loadRenderedImageBytesFromTiffStream(InputStream inputStream, int x0, int y0, int z0, int deltax, int deltay, int deltaz) {
-        SeekableStream tiffStream;
+    public static byte[] loadRenderedImageBytesFromTiffStream(@Nullable InputStream inputStream,
+                                                              int x0, int y0, int z0,
+                                                              int deltax, int deltay, int deltaz) {
         if (inputStream == null) {
             return null;
-        } else if (inputStream instanceof SeekableStream) {
-            tiffStream = (SeekableStream) inputStream;
-        } else {
-            tiffStream = new MemoryCacheSeekableStream(inputStream);
         }
-        try {
+        try (SeekableStream tiffStream = new SeekableStreamWrapper(inputStream)) {
             int numSlices = TIFFDirectory.getNumDirectories(tiffStream);
             int startZ;
             int endZ;
@@ -358,11 +355,6 @@ public class ImageUtils {
         } catch (Exception e) {
             LOG.error("Error reading TIFF image stream", e);
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                tiffStream.close();
-            } catch (IOException ignore) {
-            }
         }
     }
 
@@ -430,15 +422,11 @@ public class ImageUtils {
     @Nullable
     private static RenderedImagesWithStreams loadRenderedImageFromTiffStream(NamedSupplier<InputStream> namedInputStreamSupplier, int pageNumber) {
         Stopwatch stopwatch = Stopwatch.createStarted();
-        SeekableStream tiffStream;
         InputStream inputStream = namedInputStreamSupplier.get();
         if (inputStream == null) {
             return null;
-        } else if (inputStream instanceof SeekableStream) {
-            tiffStream = (SeekableStream) inputStream;
-        } else {
-            tiffStream = new MemoryCacheSeekableStream(inputStream);
         }
+        SeekableStream tiffStream = new SeekableStreamWrapper(inputStream);
         try {
             LOG.debug("Load page {} from {}", pageNumber, namedInputStreamSupplier.getName());
             ParameterBlock decodeTiffPB = new ParameterBlock()

--- a/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
+++ b/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
@@ -2,8 +2,10 @@ package org.janelia.rendering.utils;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,7 +54,7 @@ public class ImageUtilsTest {
         TestUtils.prepareTestDataFiles(Paths.get(TEST_DATADIR), testDirectory, "default.0.tif");
         File testFile = testDirectory.resolve("default.0.tif").toFile();
         RenderedImageInfo imageInfo;
-        try (FileSeekableStream tiffStream = new FileSeekableStream(testFile)) {
+        try (InputStream tiffStream = new FileInputStream(testFile)) {
             imageInfo = ImageUtils.loadImageInfoFromTiffStream(tiffStream);
         }
         try (FileSeekableStream tiffStream = new FileSeekableStream(testFile)) {

--- a/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
+++ b/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
@@ -1,9 +1,6 @@
 package org.janelia.rendering.utils;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -55,40 +52,30 @@ public class ImageUtilsTest {
     @Test
     public void loadTiffPixelBytes() throws IOException {
         TestUtils.prepareTestDataFiles(Paths.get(TEST_DATADIR), testDirectory, "default.0.tif");
-        File testFile = testDirectory.resolve("default.0.tif").toFile();
+        Path testFilePath = testDirectory.resolve("default.0.tif");
         RenderedImageInfo imageInfo;
-        try (InputStream tiffStream = Files.newInputStream(testFile.toPath())) {
+        try (InputStream tiffStream = Files.newInputStream(testFilePath)) {
             imageInfo = ImageUtils.loadImageInfoFromTiffStream(tiffStream);
+            assertNotNull(imageInfo);
         }
-        try (InputStream tiffStream = Files.newInputStream(testFile.toPath())) {
+        try (InputStream tiffStream = Files.newInputStream(testFilePath)) {
             byte[] imageBytes = ImageUtils.loadImagePixelBytesFromTiffStream(tiffStream, -1, -1, -1, -1, -1, -1);
+            assertNotNull(imageBytes);
             // save the bytes as tiff to make sure they can be read
-            int imageSize = imageInfo.sx * imageInfo.sy * (imageInfo.cmPixelSize / 8);
-            Iterator<BufferedImage> pagesIterator = IntStream.range(0, imageInfo.sz)
-                    .mapToObj(sliceIndex -> {
-                        BufferedImage bufferedImage = new BufferedImage(imageInfo.sx, imageInfo.sy, BufferedImage.TYPE_USHORT_GRAY);
-                        int bufferOffset = sliceIndex * imageSize;
-                        for (int y = 0; y < imageInfo.sy; y++) {
-                            for (int x = 0; x < imageInfo.sx; x++) {
-                                int pixel = imageBytes[bufferOffset] & 0x000000ff;
-                                pixel |= (imageBytes[bufferOffset + 1] & 0x000000ff) << 8;
-                                bufferedImage.setRGB(x, y, pixel);
-                                bufferOffset += 2;
-                            }
-                        }
-                        return bufferedImage;
-                    })
-                    .iterator();
-            File testOutputFile = testDirectory.resolve("outputTiff.tif").toFile();
-            OutputStream testOutputStream = Files.newOutputStream(testOutputFile.toPath());
-            TIFFEncodeParam param = new TIFFEncodeParam();
-            ImageEncoder encoder = ImageCodec.createImageEncoder("tiff", testOutputStream, param);
-            param.setExtraImages(pagesIterator);
-            encoder.encode(pagesIterator.next());
-            testOutputStream.flush();
-            testOutputStream.close();
-            try (FileSeekableStream tiffResultStream = new FileSeekableStream(testOutputFile)) {
+            Path testOutputFilePath = testDirectory.resolve("outputTiff.tif");
+            try (OutputStream testOutputStream = Files.newOutputStream(testOutputFilePath)) {
+                TIFFEncodeParam param = new TIFFEncodeParam();
+                ImageEncoder encoder = ImageCodec.createImageEncoder("tiff", testOutputStream, param);
+                Iterator<BufferedImage> pagesIterator = IntStream.range(0, imageInfo.sz)
+                        .mapToObj(sliceIndex -> extractSliceFromImageBytes(imageBytes, imageInfo, sliceIndex))
+                        .iterator();
+                param.setExtraImages(pagesIterator);
+                encoder.encode(pagesIterator.next());
+                testOutputStream.flush();
+            }
+            try (FileSeekableStream tiffResultStream = new FileSeekableStream(testOutputFilePath.toFile())) {
                 RenderedImageInfo resultImageInfo = ImageUtils.loadImageInfoFromTiffStream(tiffResultStream);
+                assertNotNull(resultImageInfo);
                 assertEquals(imageInfo.sx, resultImageInfo.sx);
                 assertEquals(imageInfo.sy, resultImageInfo.sy);
                 assertEquals(imageInfo.sz, resultImageInfo.sz);
@@ -98,19 +85,34 @@ public class ImageUtilsTest {
         }
     }
 
+    private BufferedImage extractSliceFromImageBytes(byte[] imageBytes, RenderedImageInfo imageInfo, int sliceIndex) {
+        BufferedImage bufferedImage = new BufferedImage(imageInfo.sx, imageInfo.sy, BufferedImage.TYPE_USHORT_GRAY);
+        int sliceSize = imageInfo.sx * imageInfo.sy * (imageInfo.cmPixelSize / 8);
+        int bufferOffset = sliceIndex * sliceSize;
+        for (int y = 0; y < imageInfo.sy; y++) {
+            for (int x = 0; x < imageInfo.sx; x++) {
+                int pixel = imageBytes[bufferOffset] & 0x000000ff;
+                pixel |= (imageBytes[bufferOffset + 1] & 0x000000ff) << 8;
+                bufferedImage.setRGB(x, y, pixel);
+                bufferOffset += 2;
+            }
+        }
+        return bufferedImage;
+    }
+
     @Test
     public void combineSlices() {
         TestUtils.prepareTestDataFiles(Paths.get(TEST_DATADIR), testDirectory, "default.0.tif", "default.1.tif");
-        File testFile0 = testDirectory.resolve("default.0.tif").toFile();
-        File testFile1 = testDirectory.resolve("default.1.tif").toFile();
+        Path testFile0 = testDirectory.resolve("default.0.tif");
+        Path testFile1 = testDirectory.resolve("default.1.tif");
 
         byte[] contentBytes = ImageUtils.bandMergedTextureBytesFromImageStreams(
                 Stream.of(testFile0, testFile1)
-                                .map(f  -> NamedSupplier.namedSupplier(
-                                        f.getName(),
+                                .map(p  -> NamedSupplier.namedSupplier(
+                                        p.getFileName().toString(),
                                         () -> {
                                             try {
-                                                return Files.newInputStream(f.toPath());
+                                                return Files.newInputStream(p);
                                             } catch (IOException e) {
                                                 throw new UncheckedIOException(e);
                                             }

--- a/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
+++ b/jacs-model-rendering/src/test/java/org/janelia/rendering/utils/ImageUtilsTest.java
@@ -57,10 +57,10 @@ public class ImageUtilsTest {
         TestUtils.prepareTestDataFiles(Paths.get(TEST_DATADIR), testDirectory, "default.0.tif");
         File testFile = testDirectory.resolve("default.0.tif").toFile();
         RenderedImageInfo imageInfo;
-        try (InputStream tiffStream = new FileInputStream(testFile)) {
+        try (InputStream tiffStream = Files.newInputStream(testFile.toPath())) {
             imageInfo = ImageUtils.loadImageInfoFromTiffStream(tiffStream);
         }
-        try (FileSeekableStream tiffStream = new FileSeekableStream(testFile)) {
+        try (InputStream tiffStream = Files.newInputStream(testFile.toPath())) {
             byte[] imageBytes = ImageUtils.loadImagePixelBytesFromTiffStream(tiffStream, -1, -1, -1, -1, -1, -1);
             // save the bytes as tiff to make sure they can be read
             int imageSize = imageInfo.sx * imageInfo.sy * (imageInfo.cmPixelSize / 8);
@@ -80,7 +80,7 @@ public class ImageUtilsTest {
                     })
                     .iterator();
             File testOutputFile = testDirectory.resolve("outputTiff.tif").toFile();
-            OutputStream testOutputStream = new FileOutputStream(testOutputFile);
+            OutputStream testOutputStream = Files.newOutputStream(testOutputFile.toPath());
             TIFFEncodeParam param = new TIFFEncodeParam();
             ImageEncoder encoder = ImageCodec.createImageEncoder("tiff", testOutputStream, param);
             param.setExtraImages(pagesIterator);


### PR DESCRIPTION
I found one more case when streams are left opened -  when combining slices from multiple channels in 2D viewer, such as the JADE call to: http://localhost:9881/jacsstorage/agent_api/v1/agent_storage/storage_volume/3440107200775729153/data_content/aind-open-data/exaSPIM_653158_2023-06-01_20-41-38_fusion_2023-06-12_11-58-05/octree?filterType=TIFF_MERGE_BANDS&z=7&selectedEntries=default.0.tif&entryPattern=&maxDepth=1